### PR TITLE
fifo: configure FIFO and read FIFO status.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,6 +113,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "embedded-hal-mock"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c061879892486c076c52665d6e04e3ce0b2f7bba8250874b5942963d436c65"
+dependencies = [
+ "embedded-hal",
+ "nb 0.1.3",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -148,6 +158,7 @@ dependencies = [
  "cortex-m-rt",
  "cortex-m-semihosting",
  "embedded-hal",
+ "embedded-hal-mock",
  "panic-semihosting",
  "stm32l4xx-hal",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,6 +39,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46afbd2983a5d5a7bd740ccb198caf5b82f45c40c09c0eed36052d91cb92e719"
 
 [[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
 name = "cast"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -103,6 +109,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "defmt"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62fb5df4d2b06a2dbf6ba26b49031f5f45f1aafdfca4b9259719466d362f34a0"
+dependencies = [
+ "bitflags",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "098396b763a1786b329405f69bc3677e00d45eb4534bc9f31cd23011ee2ba267"
+dependencies = [
+ "defmt-parser",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d1ce010e1a51aef925c98f12ed81a4e0e96ce0185a87c33f1b3b9c8f20749c7"
+
+[[package]]
 name = "embedded-hal"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -157,6 +192,7 @@ dependencies = [
  "cortex-m 0.6.7",
  "cortex-m-rt",
  "cortex-m-semihosting",
+ "defmt",
  "embedded-hal",
  "embedded-hal-mock",
  "panic-semihosting",
@@ -186,6 +222,30 @@ checksum = "c3d55dedd501dfd02514646e0af4d7016ce36bc12ae177ef52056989966a1eec"
 dependencies = [
  "cortex-m 0.7.1",
  "cortex-m-semihosting",
+]
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ version = "0.3.0"
 
 
 [dependencies]
+defmt = "0.3.0"
 embedded-hal = "0.2.4"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ version = "0.3.0"
 embedded-hal = "0.2.4"
 
 [dev-dependencies]
+embedded-hal-mock = "*"
 cortex-m = "0.6.2"
 cortex-m-rt = "0.6.12"
 cortex-m-semihosting = "0.3.7"

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,3 @@
+host-test:
+	$(eval TARGET = $(shell rustc -vV | sed -n 's|host: ||p'))
+	cargo test --lib --tests --target=$(TARGET)

--- a/src/fifo.rs
+++ b/src/fifo.rs
@@ -53,16 +53,18 @@ impl FifoOut {
         let mut out = [0u8; 7];
         i2c.write_read(self.address, &[ADDR], &mut out)?;
 
-        let tag = out[0] >> 3;
+        let (tag, out) = out.split_at(1);
+        let tag = tag[0] >> 3;
+        let out: &[u8; 6] = out.try_into().expect("must be 6!");
 
         match tag.try_into() {
             Ok(SensorTag::GyroscopeNC) => Ok(Value::Gyroscope(parse_gyroscope(
                 gyro_scale,
-                out[1..].try_into().unwrap(),
+                out,
             ))),
             Ok(SensorTag::AccelerometerNC) => Ok(Value::Accelerometer(parse_accelerometer(
                 accel_scale,
-                out[1..].try_into().unwrap(),
+                out,
             ))),
             _ => unimplemented!(),
         }

--- a/src/fifo.rs
+++ b/src/fifo.rs
@@ -21,10 +21,10 @@ impl TryFrom<u8> for SensorTag {
     }
 }
 
-#[derive(Debug)]
+#[derive(Copy, Clone, Debug)]
 pub enum Value {
-    Gyroscope([f64; 3]),
-    Accelerometer([f64; 3]),
+    Gyro([f64; 3]),
+    Accel([f64; 3]),
 }
 
 const ADDR: u8 = 0x78;
@@ -58,11 +58,11 @@ impl FifoOut {
         let out: &[u8; 6] = out.try_into().expect("must be 6!");
 
         match tag.try_into() {
-            Ok(SensorTag::GyroscopeNC) => Ok(Value::Gyroscope(parse_gyroscope(
+            Ok(SensorTag::GyroscopeNC) => Ok(Value::Gyro(parse_gyroscope(
                 gyro_scale,
                 out,
             ))),
-            Ok(SensorTag::AccelerometerNC) => Ok(Value::Accelerometer(parse_accelerometer(
+            Ok(SensorTag::AccelerometerNC) => Ok(Value::Accel(parse_accelerometer(
                 accel_scale,
                 out,
             ))),
@@ -87,7 +87,7 @@ mod tests {
         let mut f = FifoOut::new(crate::DEFAULT_I2C_ADDRESS);
         let v = f.pop(&mut i2c, 1., 1.).unwrap();
 
-        assert!(matches!(v, Value::Gyroscope(_)));
+        assert!(matches!(v, Value::Gyro(_)));
         println!("{:?}", v);
     }
 }

--- a/src/fifo.rs
+++ b/src/fifo.rs
@@ -1,0 +1,89 @@
+use embedded_hal::blocking::i2c::WriteRead;
+use core::convert::{TryFrom, TryInto};
+
+use crate::{parse_accelerometer, parse_gyroscope, Register};
+
+#[repr(u8)]
+pub enum SensorTag {
+    GyroscopeNC = 0x01,
+    AccelerometerNC = 0x02,
+}
+
+impl TryFrom<u8> for SensorTag {
+    type Error = ();
+
+    fn try_from(v: u8) -> Result<Self, Self::Error> {
+        match v {
+            x if x == SensorTag::GyroscopeNC as u8 => Ok(SensorTag::GyroscopeNC),
+            x if x == SensorTag::AccelerometerNC as u8 => Ok(SensorTag::AccelerometerNC),
+            _ => Err(()),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum Value {
+    Gyroscope([f64; 3]),
+    Accelerometer([f64; 3]),
+}
+
+const ADDR: u8 = 0x78;
+
+pub struct FifoOut;
+
+impl Register for FifoOut {}
+
+impl FifoOut {
+    pub fn new() -> Self {
+        FifoOut
+    }
+
+    /// Pop a value from the FIFO.
+    pub fn pop<I2C>(
+        &mut self,
+        i2c: &mut I2C,
+        gyro_scale: f64,
+        accel_scale: f64,
+    ) -> Result<Value, I2C::Error>
+    where
+        I2C: WriteRead,
+    {
+        let mut out = [0u8; 7];
+        i2c.write_read(crate::I2C_ADDRESS, &[ADDR], &mut out)?;
+
+        let tag = out[0] >> 3;
+
+        match tag.try_into() {
+            Ok(SensorTag::GyroscopeNC) => Ok(Value::Gyroscope(parse_gyroscope(
+                gyro_scale,
+                out[1..].try_into().unwrap(),
+            ))),
+            Ok(SensorTag::AccelerometerNC) => Ok(Value::Accelerometer(parse_accelerometer(
+                accel_scale,
+                out[1..].try_into().unwrap(),
+            ))),
+            _ => unimplemented!(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use embedded_hal_mock::i2c::{Mock, Transaction};
+
+    #[test]
+    fn test_pop_gyro() {
+        let mut i2c = Mock::new(&[Transaction::write_read(
+            0x6a,
+            vec![0x78],
+            vec![0x01 << 3, 0, 1, 0, 2, 0, 4],
+        )]);
+
+        let mut f = FifoOut;
+        let v = f.pop(&mut i2c, 1., 1.).unwrap();
+
+        assert!(matches!(v, Value::Gyroscope(_)));
+        println!("{:?}", v);
+    }
+}

--- a/src/fifoctrl.rs
+++ b/src/fifoctrl.rs
@@ -1,0 +1,128 @@
+use core::fmt;
+use embedded_hal::blocking::i2c::Write;
+
+use crate::Register;
+
+/// The FIFO_CTRL1 to FIFO_CTRL4 registers
+///
+/// The four registers are handled as one because values and functionality is split across several
+/// registers.
+pub struct FifoCtrl([u8; 4]);
+
+impl fmt::Display for FifoCtrl {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        for r in self.0.iter() {
+            write!(f, "{}", r)?;
+        }
+
+        Ok(())
+    }
+}
+
+impl fmt::Binary for FifoCtrl {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        for r in self.0.iter() {
+            write!(f, "{:b}", r)?;
+        }
+
+        Ok(())
+    }
+}
+
+impl fmt::LowerHex for FifoCtrl {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        for r in self.0.iter() {
+            fmt::LowerHex::fmt(&r, f)?;
+        }
+
+        Ok(())
+    }
+}
+
+pub const ADDR: u8 = 0x07_u8;
+
+impl Register for FifoCtrl {}
+
+/// FIFO mode
+///
+/// Default value is `Bypass` (off).
+#[repr(u8)]
+pub enum FifoMode {
+    Bypass = 0b000,
+    FifoMode = 0b001,
+    ContinuousToFifo = 0b011,
+    BypassToContinuous = 0b100,
+    Conitnous = 0b110,
+    BypassToFifo = 0b111,
+}
+
+impl FifoCtrl {
+    pub fn new(bits: [u8; 4]) -> Self {
+        FifoCtrl(bits)
+    }
+
+    /// Enable compression of values in FIFO, increasing FIFO size from 3kB to maximum 9kB.
+    pub fn compression<I2C>(&mut self, i2c: &mut I2C, value: bool) -> Result<(), I2C::Error>
+    where
+        I2C: Write,
+    {
+        self.0[1] &= !(1 << 6);
+        self.0[1] |= (value as u8) << 6;
+        self.write(i2c, ADDR + 1, self.0[1])
+    }
+
+    /// Set the FIFO mode (or disable FIFO)
+    pub fn mode<I2C>(&mut self, i2c: &mut I2C, mode: FifoMode) -> Result<(), I2C::Error>
+    where
+        I2C: Write,
+    {
+        const RESET: u8 = 0b111;
+
+        self.0[3] &= !RESET;
+        self.0[3] |= mode as u8;
+        self.write(i2c, ADDR + 3, self.0[3])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use embedded_hal_mock::i2c::{Mock, Transaction};
+
+    #[test]
+    fn test_compression() {
+        let mut i2c = Mock::new(&[Transaction::write(0x6a, vec![0x08, 0b1000000])]);
+
+        let mut f = FifoCtrl([0; 4]);
+
+        f.compression(&mut i2c, true).unwrap();
+        assert_eq!(f.0[1], 0b1000000);
+    }
+
+    #[test]
+    fn test_sub_addresses() {
+        let r2 = ADDR + 1;
+        let r3 = ADDR + 2;
+        let r4 = ADDR + 3;
+
+        assert_eq!(ADDR, 0x07);
+        assert_eq!(r2, 0x08);
+        assert_eq!(r3, 0x09);
+        assert_eq!(r4, 0x0a);
+    }
+
+    #[test]
+    fn set_mode() {
+        let mut i2c = Mock::new(&[
+            Transaction::write(0x6a, vec![0x0a, 0b0000000]),
+            Transaction::write(0x6a, vec![0x0a, 0b0000001]),
+        ]);
+        let mut f = FifoCtrl([0; 4]);
+
+        f.mode(&mut i2c, FifoMode::Bypass).unwrap();
+        assert_eq!(f.0[3], 0b0000000);
+
+        f.mode(&mut i2c, FifoMode::FifoMode).unwrap();
+        assert_eq!(f.0[3], 0b0000001);
+    }
+}

--- a/src/fifoctrl.rs
+++ b/src/fifoctrl.rs
@@ -44,6 +44,9 @@ impl fmt::LowerHex for FifoCtrl {
 
 pub const ADDR: u8 = 0x07_u8;
 
+/// The maximum number of samples in an uncompressed FIFO.
+pub const FIFO_SIZE: u16 = 512;
+
 impl Register for FifoCtrl {}
 
 /// FIFO mode

--- a/src/fifoctrl.rs
+++ b/src/fifoctrl.rs
@@ -58,7 +58,7 @@ pub enum FifoMode {
     FifoMode = 0b001,
     ContinuousToFifo = 0b011,
     BypassToContinuous = 0b100,
-    Conitnous = 0b110,
+    Continuous = 0b110,
     BypassToFifo = 0b111,
 }
 

--- a/src/fifostatus.rs
+++ b/src/fifostatus.rs
@@ -3,15 +3,17 @@ use embedded_hal::blocking::i2c::WriteRead;
 use crate::Register;
 
 /// The FIFO_STATUS registers.
-pub struct FifoStatus;
+pub struct FifoStatus {
+    pub address: u8,
+}
 
 pub const ADDR: u8 = 0x3a_u8;
 
 impl Register for FifoStatus {}
 
 impl FifoStatus {
-    pub fn new() -> Self {
-        FifoStatus
+    pub fn new(address: u8) -> Self {
+        FifoStatus { address }
     }
 
     /// Is the FIFO full
@@ -19,7 +21,7 @@ impl FifoStatus {
     where
         I2C: WriteRead,
     {
-        let v = self.read(i2c, ADDR + 1)?;
+        let v = self.read(i2c, self.address, ADDR + 1)?;
 
         Ok(v & (1 << 5) != 0)
     }
@@ -29,7 +31,7 @@ impl FifoStatus {
     where
         I2C: WriteRead,
     {
-        let v = self.read(i2c, ADDR + 1)?;
+        let v = self.read(i2c, self.address, ADDR + 1)?;
 
         Ok(v & (1 << 6) != 0)
     }
@@ -39,7 +41,7 @@ impl FifoStatus {
     where
         I2C: WriteRead,
     {
-        let v = self.read(i2c, ADDR + 1)?;
+        let v = self.read(i2c, self.address, ADDR + 1)?;
 
         Ok(v & (1 << 7) != 0)
     }
@@ -49,7 +51,7 @@ impl FifoStatus {
     where
         I2C: WriteRead,
     {
-        let v = self.read(i2c, ADDR + 1)?;
+        let v = self.read(i2c, self.address, ADDR + 1)?;
 
         Ok(v & (1 << 3) != 0)
     }
@@ -59,7 +61,7 @@ impl FifoStatus {
     where
         I2C: WriteRead,
     {
-        let v = self.read(i2c, ADDR + 1)?;
+        let v = self.read(i2c, self.address, ADDR + 1)?;
 
         Ok(v & (1 << 4) != 0)
     }
@@ -69,10 +71,11 @@ impl FifoStatus {
     where
         I2C: WriteRead,
     {
-        let v0 = self.read(i2c, ADDR + 0)?;
-        let v1 = self.read(i2c, ADDR + 1)? & 0b11;
+        let mut v = [0u8; 2];
+        i2c.write_read(self.address, &[ADDR], &mut v)?;
+        v[1] &= 0b11;
 
-        Ok(u16::from_le_bytes([v0, v1]))
+        Ok(u16::from_le_bytes(v))
     }
 }
 
@@ -83,22 +86,21 @@ mod tests {
 
     #[test]
     fn test_full() {
-        let mut i2c = Mock::new(&[
-            Transaction::write_read(0x6a, vec![0x3b], vec![0b100000]),
-        ]);
+        let mut i2c = Mock::new(&[Transaction::write_read(0x6b, vec![0x3b], vec![0b100000])]);
 
-        let mut f = FifoStatus;
+        let mut f = FifoStatus::new(crate::DEFAULT_I2C_ADDRESS);
         assert!(f.full(&mut i2c).unwrap());
     }
 
     #[test]
     fn test_diff_1b() {
-        let mut i2c = Mock::new(&[
-            Transaction::write_read(0x6a, vec![0x3a], vec![0b00100000_u8]),
-            Transaction::write_read(0x6a, vec![0x3b], vec![0b00000000_u8]),
-        ]);
+        let mut i2c = Mock::new(&[Transaction::write_read(
+            0x6b,
+            vec![0x3a],
+            vec![0b00100000_u8, 0b00000000_u8],
+        )]);
 
-        let mut f = FifoStatus;
+        let mut f = FifoStatus::new(crate::DEFAULT_I2C_ADDRESS);
         let diff = f.diff_fifo(&mut i2c).unwrap();
 
         assert_eq!(diff, 0b000100000);
@@ -106,12 +108,13 @@ mod tests {
 
     #[test]
     fn test_diff_2b() {
-        let mut i2c = Mock::new(&[
-            Transaction::write_read(0x6a, vec![0x3a], vec![0b00100000_u8]),
-            Transaction::write_read(0x6a, vec![0x3b], vec![0b00000001_u8]),
-        ]);
+        let mut i2c = Mock::new(&[Transaction::write_read(
+            0x6b,
+            vec![0x3a],
+            vec![0b00100000_u8, 0b00000001_u8],
+        )]);
 
-        let mut f = FifoStatus;
+        let mut f = FifoStatus::new(crate::DEFAULT_I2C_ADDRESS);
         let diff = f.diff_fifo(&mut i2c).unwrap();
 
         assert_eq!(diff, 0b100100000);

--- a/src/fifostatus.rs
+++ b/src/fifostatus.rs
@@ -1,0 +1,119 @@
+use embedded_hal::blocking::i2c::WriteRead;
+
+use crate::Register;
+
+/// The FIFO_STATUS registers.
+pub struct FifoStatus;
+
+pub const ADDR: u8 = 0x3a_u8;
+
+impl Register for FifoStatus {}
+
+impl FifoStatus {
+    pub fn new() -> Self {
+        FifoStatus
+    }
+
+    /// Is the FIFO full
+    pub fn full<I2C>(&mut self, i2c: &mut I2C) -> Result<bool, I2C::Error>
+    where
+        I2C: WriteRead,
+    {
+        let v = self.read(i2c, ADDR + 1)?;
+
+        Ok(v & (1 << 5) != 0)
+    }
+
+    /// Is the FIFO overrun
+    pub fn overrun<I2C>(&mut self, i2c: &mut I2C) -> Result<bool, I2C::Error>
+    where
+        I2C: WriteRead,
+    {
+        let v = self.read(i2c, ADDR + 1)?;
+
+        Ok(v & (1 << 6) != 0)
+    }
+
+    /// Is the FIFO watermark reached.
+    pub fn watermark_reached<I2C>(&mut self, i2c: &mut I2C) -> Result<bool, I2C::Error>
+    where
+        I2C: WriteRead,
+    {
+        let v = self.read(i2c, ADDR + 1)?;
+
+        Ok(v & (1 << 7) != 0)
+    }
+
+    /// Latched FIFO overrun status.
+    pub fn overrun_latched<I2C>(&mut self, i2c: &mut I2C) -> Result<bool, I2C::Error>
+    where
+        I2C: WriteRead,
+    {
+        let v = self.read(i2c, ADDR + 1)?;
+
+        Ok(v & (1 << 3) != 0)
+    }
+
+    /// Counter BDR reached.
+    pub fn count_bdr_reached<I2C>(&mut self, i2c: &mut I2C) -> Result<bool, I2C::Error>
+    where
+        I2C: WriteRead,
+    {
+        let v = self.read(i2c, ADDR + 1)?;
+
+        Ok(v & (1 << 4) != 0)
+    }
+
+    /// Number of unread sensor data in FIFO.
+    pub fn diff_fifo<I2C>(&mut self, i2c: &mut I2C) -> Result<u16, I2C::Error>
+    where
+        I2C: WriteRead,
+    {
+        let v0 = self.read(i2c, ADDR + 0)?;
+        let v1 = self.read(i2c, ADDR + 1)? & 0b11;
+
+        Ok(u16::from_le_bytes([v0, v1]))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use embedded_hal_mock::i2c::{Mock, Transaction};
+
+    #[test]
+    fn test_full() {
+        let mut i2c = Mock::new(&[
+            Transaction::write_read(0x6a, vec![0x3b], vec![0b100000]),
+        ]);
+
+        let mut f = FifoStatus;
+        assert!(f.full(&mut i2c).unwrap());
+    }
+
+    #[test]
+    fn test_diff_1b() {
+        let mut i2c = Mock::new(&[
+            Transaction::write_read(0x6a, vec![0x3a], vec![0b00100000_u8]),
+            Transaction::write_read(0x6a, vec![0x3b], vec![0b00000000_u8]),
+        ]);
+
+        let mut f = FifoStatus;
+        let diff = f.diff_fifo(&mut i2c).unwrap();
+
+        assert_eq!(diff, 0b000100000);
+    }
+
+    #[test]
+    fn test_diff_2b() {
+        let mut i2c = Mock::new(&[
+            Transaction::write_read(0x6a, vec![0x3a], vec![0b00100000_u8]),
+            Transaction::write_read(0x6a, vec![0x3b], vec![0b00000001_u8]),
+        ]);
+
+        let mut f = FifoStatus;
+        let diff = f.diff_fifo(&mut i2c).unwrap();
+
+        assert_eq!(diff, 0b100100000);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,7 +121,7 @@ impl Ism330Dhcx {
     where
         I2C: WriteRead<Error = E> + Write<Error = E>,
     {
-        let mut registers = [0u8; 9];
+        let mut registers = [0u8; 13];
         i2c.write_read(address, &[0x10], &mut registers)?;
 
         let ctrl1xl = Ctrl1Xl::new(registers[0], address);
@@ -129,7 +129,7 @@ impl Ism330Dhcx {
         let ctrl3c = Ctrl3C::new(registers[2], address);
         let ctrl7g = Ctrl7G::new(registers[6], address);
         let ctrl9xl = Ctrl9Xl::new(registers[8], address);
-        let fifoctrl = FifoCtrl::new(registers[9..14].try_into().unwrap(), address);
+        let fifoctrl = FifoCtrl::new(registers[9..13].try_into().unwrap(), address);
         let fifostatus = FifoStatus::new(address);
 
         let ism330dhcx = Ism330Dhcx {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -155,6 +155,7 @@ impl Ism330Dhcx {
         self.fifostatus.address = address;
     }
 
+    /// Get temperature in Celsius.
     pub fn get_temperature<I2C>(&mut self, i2c: &mut I2C) -> Result<f32, I2C::Error>
     where
         I2C: WriteRead,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -201,7 +201,7 @@ impl Ism330Dhcx {
         let gyro_scale = self.ctrl2g.chain_full_scale();
         let accel_scale = self.ctrl1xl.chain_full_scale();
 
-        fifo::FifoOut::new().pop(i2c, gyro_scale, accel_scale)
+        fifo::FifoOut::new(self.address).pop(i2c, gyro_scale, accel_scale)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -179,7 +179,7 @@ impl Ism330Dhcx {
         let mut measurements = [0u8; 6];
         i2c.write_read(self.address, &[0x22], &mut measurements)?;
 
-        Ok(parse_gyroscope(scale, measurements))
+        Ok(parse_gyroscope(scale, &measurements))
     }
 
     pub fn get_accelerometer<I2C>(&mut self, i2c: &mut I2C) -> Result<[f64; 3], I2C::Error>
@@ -191,7 +191,7 @@ impl Ism330Dhcx {
         let mut measurements = [0u8; 6];
         i2c.write_read(self.address, &[0x28], &mut measurements)?;
 
-        Ok(parse_accelerometer(scale, measurements))
+        Ok(parse_accelerometer(scale, &measurements))
     }
 
     pub fn fifo_pop<I2C>(&mut self, i2c: &mut I2C) -> Result<fifo::Value, I2C::Error>
@@ -205,7 +205,7 @@ impl Ism330Dhcx {
     }
 }
 
-pub(crate) fn parse_gyroscope(scale: f64, measurements: [u8; 6]) -> [f64; 3] {
+pub(crate) fn parse_gyroscope(scale: f64, measurements: &[u8; 6]) -> [f64; 3] {
     let raw_gyro_x = (measurements[1] as i16) << 8 | (measurements[0] as i16);
     let raw_gyro_y = (measurements[3] as i16) << 8 | (measurements[2] as i16);
     let raw_gyro_z = (measurements[5] as i16) << 8 | (measurements[4] as i16);
@@ -217,7 +217,7 @@ pub(crate) fn parse_gyroscope(scale: f64, measurements: [u8; 6]) -> [f64; 3] {
     [gyro_x, gyro_y, gyro_z]
 }
 
-pub(crate) fn parse_accelerometer(scale: f64, measurements: [u8; 6]) -> [f64; 3] {
+pub(crate) fn parse_accelerometer(scale: f64, measurements: &[u8; 6]) -> [f64; 3] {
     let raw_acc_x = (measurements[1] as i16) << 8 | (measurements[0] as i16);
     let raw_acc_y = (measurements[3] as i16) << 8 | (measurements[2] as i16);
     let raw_acc_z = (measurements[5] as i16) << 8 | (measurements[4] as i16);


### PR DESCRIPTION
You can test on host by doing `make host-test`. You have to add `embedded-hal-mock` as a dev-dependency, the stm crate doesn't resolve for me so I had to disable all the deps related to the example -- and thus it was a pain to add this new dep.