### PR TITLE
gyro and accel scale wrong: should be specified in milli-unit per bit!

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -167,26 +176,24 @@ dependencies = [
 
 [[package]]
 name = "fugit"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ab17bb279def6720d058cb6c052249938e7f99260ab534879281a95367a87e5"
+checksum = "17186ad64927d5ac8f02c1e77ccefa08ccd9eaa314d5a4772278aa204a22f7e7"
 dependencies = [
  "gcd",
 ]
 
 [[package]]
 name = "gcd"
-version = "2.1.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f37978dab2ca789938a83b2f8bc1ef32db6633af9051a6cd409eff72cbaaa79a"
-dependencies = [
- "paste",
-]
+checksum = "1d758ba1b47b00caf47f24925c0074ecb20d6dfcffe7f6d53395c0465674841a"
 
 [[package]]
 name = "ism330dhcx"
 version = "0.5.1"
 dependencies = [
+ "approx",
  "cortex-m",
  "cortex-m-rt",
  "cortex-m-semihosting",
@@ -286,12 +293,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "paste"
-version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1de2e551fb905ac83f73f7aedf2f0cb4a0da7e35efa24a202a936269f1f18e1"
-
-[[package]]
 name = "proc-macro-error"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -354,7 +355,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
- "semver 1.0.14",
+ "semver 1.0.20",
 ]
 
 [[package]]
@@ -368,9 +369,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.14"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e25dfac463d778e353db5be2449d1cce89bd6fd23c9f1ea21310ce6e5a1b29c4"
+checksum = "836fa6a3e1e547f9a2c4040802ec865b5d85f4014efe00555d7090a3dcaa1090"
 
 [[package]]
 name = "semver-parser"
@@ -452,9 +453,9 @@ checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "volatile-register"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ee8f19f9d74293faf70901bc20ad067dc1ad390d2cbf1e3f75f721ffee908b6"
+checksum = "de437e2a6208b014ab52972a27e59b33fa2920d3e00fe05026167a1c509d19cc"
 dependencies = [
  "vcell",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,10 +24,10 @@ defmt = "0.3.5"
 embedded-hal = "0.2.7"
 
 [dev-dependencies]
+approx = "0.5.1"
 cortex-m = "0.7.7"
 cortex-m-rt = "0.7.3"
 cortex-m-semihosting = "0.5.0"
-embedded-hal = "0.2.7"
 panic-semihosting = "0.6.0"
 stm32l4xx-hal = { version = "0.7.1", features = ["rt", "stm32l433"] }
 

--- a/src/fifo.rs
+++ b/src/fifo.rs
@@ -1,7 +1,7 @@
 use core::convert::{TryFrom, TryInto};
 use embedded_hal::blocking::i2c::WriteRead;
 
-use crate::{parse_accelerometer, parse_gyroscope, Register};
+use crate::{ctrl1xl, ctrl2g, AccelValue, GyroValue, Register};
 
 #[repr(u8)]
 pub enum SensorTag {
@@ -28,8 +28,8 @@ impl TryFrom<u8> for SensorTag {
 #[derive(Copy, Clone, Debug, defmt::Format)]
 pub enum Value {
     Empty,
-    Gyro([f64; 3]),
-    Accel([f64; 3]),
+    Gyro(GyroValue),
+    Accel(AccelValue),
     Other(u8, [u8; 6]),
 }
 
@@ -50,8 +50,8 @@ impl FifoOut {
     pub fn pop<I2C>(
         &mut self,
         i2c: &mut I2C,
-        gyro_scale: f64,
-        accel_scale: f64,
+        gyro_scale: ctrl2g::Fs,
+        accel_scale: ctrl1xl::Fs_Xl,
     ) -> Result<Value, I2C::Error>
     where
         I2C: WriteRead,
@@ -65,9 +65,9 @@ impl FifoOut {
 
         match tag.try_into() {
             Ok(SensorTag::Empty) => Ok(Value::Empty),
-            Ok(SensorTag::GyroscopeNC) => Ok(Value::Gyro(parse_gyroscope(gyro_scale, out))),
+            Ok(SensorTag::GyroscopeNC) => Ok(Value::Gyro(GyroValue::from_msr(gyro_scale, out))),
             Ok(SensorTag::AccelerometerNC) => {
-                Ok(Value::Accel(parse_accelerometer(accel_scale, out)))
+                Ok(Value::Accel(AccelValue::from_msr(accel_scale, out)))
             }
             Ok(SensorTag::Other(u)) => Ok(Value::Other(u, *out)),
             _ => unreachable!(),
@@ -89,7 +89,9 @@ mod tests {
         )]);
 
         let mut f = FifoOut::new(crate::DEFAULT_I2C_ADDRESS);
-        let v = f.pop(&mut i2c, 250., 2.).unwrap();
+        let v = f
+            .pop(&mut i2c, ctrl2g::Fs::Dps250, ctrl1xl::Fs_Xl::G2)
+            .unwrap();
 
         assert!(matches!(v, Value::Gyro(_)));
         println!("{:?}", v);

--- a/src/fifo.rs
+++ b/src/fifo.rs
@@ -16,9 +16,9 @@ impl TryFrom<u8> for SensorTag {
 
     fn try_from(v: u8) -> Result<Self, Self::Error> {
         match v {
-            x if x == 0x00 => Ok(SensorTag::Empty),
-            x if x == 0x01 => Ok(SensorTag::GyroscopeNC),
-            x if x == 0x02 => Ok(SensorTag::AccelerometerNC),
+            0x00 => Ok(SensorTag::Empty),
+            0x01 => Ok(SensorTag::GyroscopeNC),
+            0x02 => Ok(SensorTag::AccelerometerNC),
             x if x <= 0x19 => Ok(SensorTag::Other(x)),
             _ => Err(()),
         }

--- a/src/fifo.rs
+++ b/src/fifo.rs
@@ -89,7 +89,7 @@ mod tests {
         )]);
 
         let mut f = FifoOut::new(crate::DEFAULT_I2C_ADDRESS);
-        let v = f.pop(&mut i2c, 1., 1.).unwrap();
+        let v = f.pop(&mut i2c, 250., 2.).unwrap();
 
         assert!(matches!(v, Value::Gyro(_)));
         println!("{:?}", v);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -210,6 +210,9 @@ pub(crate) fn parse_gyroscope(scale: f64, measurements: &[u8; 6]) -> [f64; 3] {
     let raw_gyro_y = (measurements[3] as i16) << 8 | (measurements[2] as i16);
     let raw_gyro_z = (measurements[5] as i16) << 8 | (measurements[4] as i16);
 
+    // Range is in milli-dps per bit!
+    let scale = scale * 1000. / i16::MAX as f64;
+
     let gyro_x = raw_gyro_x as f64 * scale * SENSORS_DPS_TO_RADS / 1000.0;
     let gyro_y = raw_gyro_y as f64 * scale * SENSORS_DPS_TO_RADS / 1000.0;
     let gyro_z = raw_gyro_z as f64 * scale * SENSORS_DPS_TO_RADS / 1000.0;
@@ -221,6 +224,9 @@ pub(crate) fn parse_accelerometer(scale: f64, measurements: &[u8; 6]) -> [f64; 3
     let raw_acc_x = (measurements[1] as i16) << 8 | (measurements[0] as i16);
     let raw_acc_y = (measurements[3] as i16) << 8 | (measurements[2] as i16);
     let raw_acc_z = (measurements[5] as i16) << 8 | (measurements[4] as i16);
+
+    // Range is in milli-g per bit!
+    let scale = scale * 1000. / i16::MAX as f64;
 
     let acc_x = raw_acc_x as f64 * scale * SENSORS_GRAVITY_STANDARD / 1000.0;
     let acc_y = raw_acc_y as f64 * scale * SENSORS_GRAVITY_STANDARD / 1000.0;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -218,7 +218,7 @@ pub(crate) fn parse_gyroscope(scale: f64, measurements: &[u8; 6]) -> [f64; 3] {
         1000. => 35.,
         2000. => 70.,
         4000. => 140.,
-        _ => unreachable!()
+        _ => unreachable!(),
     };
 
     let gyro_x = raw_gyro_x as f64 * sens * SENSORS_DPS_TO_RADS / 1000.;
@@ -239,7 +239,7 @@ pub(crate) fn parse_accelerometer(scale: f64, measurements: &[u8; 6]) -> [f64; 3
         4. => 0.122,
         8. => 0.244,
         16. => 0.488,
-        _ => unreachable!()
+        _ => unreachable!(),
     };
 
     let acc_x = raw_acc_x as f64 * sens * SENSORS_GRAVITY_STANDARD / 1000.0;
@@ -257,7 +257,10 @@ mod tests {
     #[test]
     fn parse_acceleromtere_2g() {
         // Table 19 in AN5398
-        assert_eq!(parse_accelerometer(2., &[0x0, 0x0, 0x0, 0x0, 0x0, 0x0]), [0., 0., 0.]);
+        assert_eq!(
+            parse_accelerometer(2., &[0x0, 0x0, 0x0, 0x0, 0x0, 0x0]),
+            [0., 0., 0.]
+        );
 
         let a = parse_accelerometer(2., &[0x69, 0x16, 0x0, 0x0, 0x0, 0x0]);
         assert_abs_diff_eq!(a[0], 0.350 * SENSORS_GRAVITY_STANDARD, epsilon = 0.01);
@@ -275,7 +278,10 @@ mod tests {
     #[test]
     fn parse_gyro_250dps() {
         // Table 19 in AN5398
-        assert_eq!(parse_gyroscope(250., &[0x0, 0x0, 0x0, 0x0, 0x0, 0x0]), [0., 0., 0.]);
+        assert_eq!(
+            parse_gyroscope(250., &[0x0, 0x0, 0x0, 0x0, 0x0, 0x0]),
+            [0., 0., 0.]
+        );
 
         let a = parse_gyroscope(250., &[0xa4, 0x2c, 0x0, 0x0, 0x0, 0x0]);
         assert_abs_diff_eq!(a[0], 100. * SENSORS_DPS_TO_RADS, epsilon = 0.01);


### PR DESCRIPTION
possibly also wrong in Adafruit driver: https://github.com/adafruit/Adafruit_LSM6DS/issues/40

this gives better values for acceleration when using other scales than
2.

Please take a good look on this one, not sure if it is correct.
